### PR TITLE
Fix grid header size and hover text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,11 @@
                    font-size: 12px !important;
                }
 
+               /* Garantir texto preto em hover nas linhas pai */
+               .e-gantt .e-row:hover .e-treerowcell .e-treecell {
+                   color: #ffffff !important;
+               }
+
                /* CÉLULAS COMPACTAS */
                .e-rowcell {
                    border-right: 1px solid #f3f4f6 !important;

--- a/index.html
+++ b/index.html
@@ -132,11 +132,6 @@
                    font-size: 12px !important;
                }
 
-               /* Garantir texto preto em hover nas linhas pai */
-               .e-gantt .e-row:hover .e-treerowcell .e-treecell {
-                   color: #ffffff !important;
-               }
-
                /* CÉLULAS COMPACTAS */
                .e-rowcell {
                    border-right: 1px solid #f3f4f6 !important;

--- a/index.html
+++ b/index.html
@@ -144,15 +144,15 @@
                    background: #f8f9fa !important;
                    border: none !important;
                    font-weight: 500 !important;
-                   height: 60px !important;
+                   height: 48px !important;
                }
 
                .e-timeline-header-cell {
                    border-right: 1px solid #e5e7eb !important;
                    color: #374151 !important;
-                   font-size: 10px !important;
+                   font-size: 9px !important;
                    font-weight: 500 !important;
-                   padding: 4px !important;
+                   padding: 2px !important;
                }
 
                /* BARRAS DE TAREFA EXECUTIVAS */

--- a/index.html
+++ b/index.html
@@ -62,12 +62,28 @@
                    background: #fef3e2 !important;
                }
 
+               .e-gantt .e-row:hover .e-rowcell {
+                   color: #000000 !important;
+               }
+
+               .e-gantt .e-row:hover .e-treecell {
+                   color: #000000 !important;
+               }
+
                .e-gantt .e-row.e-altrow {
                    background: #fafbfc !important;
                }
 
                .e-gantt .e-row.e-altrow:hover {
                    background: #fef3e2 !important;
+               }
+
+               .e-gantt .e-row.e-altrow:hover .e-rowcell {
+                   color: #000000 !important;
+               }
+
+               .e-gantt .e-row.e-altrow:hover .e-treecell {
+                   color: #000000 !important;
                }
 
                /* TAREFAS PAI - ESTILO EXECUTIVO */

--- a/index.html
+++ b/index.html
@@ -80,6 +80,16 @@
                    color: #000000 !important;
                }
 
+               /* Texto preto específico para grupos pai em hover */
+               .e-gantt .e-row:hover .e-treerowcell {
+                   color: #000000 !important;
+                   background: #fef3e2 !important;
+               }
+
+               .e-gantt .e-row:hover .e-treerowcell .e-treecell {
+                   color: #000000 !important;
+               }
+
                .e-gantt .e-row.e-altrow {
                    background: #fafbfc !important;
                }
@@ -93,6 +103,15 @@
                }
 
                .e-gantt .e-row.e-altrow:hover .e-treecell {
+                   color: #000000 !important;
+               }
+
+               .e-gantt .e-row.e-altrow:hover .e-treerowcell {
+                   color: #000000 !important;
+                   background: #fef3e2 !important;
+               }
+
+               .e-gantt .e-row.e-altrow:hover .e-treerowcell .e-treecell {
                    color: #000000 !important;
                }
 

--- a/index.html
+++ b/index.html
@@ -40,15 +40,25 @@
                    border-right: 1px solid #e5e7eb !important;
                    color: #374151 !important;
                    font-weight: 600 !important;
-                   font-size: 10px !important;
+                   font-size: 9px !important;
                    text-transform: uppercase !important;
-                   letter-spacing: 0.5px !important;
-                   padding: 4px 3px !important;
-                   height: 24px !important;
+                   letter-spacing: 0.3px !important;
+                   padding: 2px 3px !important;
+                   height: 18px !important;
+                   line-height: 14px !important;
                }
 
                .e-headercell .e-headertext {
                    color: #374151 !important;
+               }
+
+               .e-columnheader {
+                   height: 18px !important;
+               }
+
+               .e-headercell .e-headercelldiv {
+                   height: 14px !important;
+                   line-height: 14px !important;
                }
 
                /* LINHAS COMPACTAS */

--- a/index.html
+++ b/index.html
@@ -168,15 +168,16 @@
                    background: #f8f9fa !important;
                    border: none !important;
                    font-weight: 500 !important;
-                   height: 48px !important;
+                   height: 36px !important;
                }
 
                .e-timeline-header-cell {
                    border-right: 1px solid #e5e7eb !important;
                    color: #374151 !important;
-                   font-size: 9px !important;
+                   font-size: 8px !important;
                    font-weight: 500 !important;
-                   padding: 2px !important;
+                   padding: 1px !important;
+                   line-height: 12px !important;
                }
 
                /* BARRAS DE TAREFA EXECUTIVAS */

--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@
                    border-right: 1px solid #e5e7eb !important;
                    color: #374151 !important;
                    font-weight: 600 !important;
-                   font-size: 11px !important;
+                   font-size: 10px !important;
                    text-transform: uppercase !important;
                    letter-spacing: 0.5px !important;
-                   padding: 8px 6px !important;
-                   height: 32px !important;
+                   padding: 4px 3px !important;
+                   height: 24px !important;
                }
 
                .e-headercell .e-headertext {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two critical usability issues:
- Grid header was too large and taking up excessive space
- Text color on hover was too light (white), making it difficult for users to read content when hovering over groups

## Code changes

**Header size reduction:**
- Reduced header cell font size from 11px to 9px
- Decreased padding from 8px 6px to 2px 3px  
- Reduced header height from 32px to 18px
- Added line-height controls for better text alignment
- Reduced timeline header height from 60px to 36px
- Adjusted timeline header font size from 10px to 8px

**Hover text visibility improvements:**
- Added black text color (#000000) for all hover states on row cells
- Applied black text specifically to tree cells and tree row cells on hover
- Ensured hover text visibility for both regular and alternate rows
- Maintained hover background color while fixing text contrast

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f60f9cede1f465fb3fb18f85c834644/glow-haven)

👀 [Preview Link](https://7f60f9cede1f465fb3fb18f85c834644-glow-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f60f9cede1f465fb3fb18f85c834644</projectId>-->
<!--<branchName>glow-haven</branchName>-->