### PR TITLE
Add single-click editing functionality to Gantt chart

### DIFF
--- a/main.js
+++ b/main.js
@@ -365,4 +365,58 @@ ganttChart.dataBound = function() {
             ganttChart.fitToProject();
         }, 100);
     }
+
+    // Adicionar evento de clique simples para edição
+    setTimeout(function() {
+        addClickEditFunctionality();
+    }, 200);
 };
+
+// Função para adicionar funcionalidade de edição por clique simples
+function addClickEditFunctionality() {
+    var gridContent = ganttChart.element.querySelector('.e-gridcontent');
+    if (gridContent) {
+        // Remover eventos anteriores para evitar duplicação
+        gridContent.removeEventListener('click', handleCellClick);
+        // Adicionar novo evento
+        gridContent.addEventListener('click', handleCellClick);
+    }
+}
+
+// Handler para clique nas células
+function handleCellClick(event) {
+    var target = event.target;
+
+    // Verificar se clicou em uma célula editável
+    var cell = target.closest('td.e-rowcell');
+    if (!cell) return;
+
+    var row = cell.closest('tr.e-row');
+    if (!row) return;
+
+    // Verificar se a célula é editável
+    var cellIndex = Array.from(row.children).indexOf(cell);
+    var columns = ganttChart.columns;
+
+    if (columns[cellIndex] && columns[cellIndex].allowEditing !== false && columns[cellIndex].field !== 'TaskID') {
+        // Verificar se é linha pai e se estamos clicando na coluna TaskName
+        var isParentRow = row.querySelector('.e-treegridexpand, .e-treegridcollapse');
+        if (isParentRow && columns[cellIndex].field === 'TaskName') {
+            return; // Não permitir edição do nome em tarefas pai
+        }
+
+        // Selecionar a linha primeiro
+        var rowIndex = Array.from(row.parentNode.children).indexOf(row);
+        ganttChart.selectRow(rowIndex);
+
+        // Ativar edição com um pequeno delay
+        setTimeout(function() {
+            var dblClickEvent = new MouseEvent('dblclick', {
+                bubbles: true,
+                cancelable: true,
+                view: window
+            });
+            cell.dispatchEvent(dblClickEvent);
+        }, 100);
+    }
+}


### PR DESCRIPTION
## Purpose
The user requested to restore single-click editing functionality that was previously lost in their Gantt chart project. They wanted to be able to edit cells by clicking once instead of requiring double-click.

## Code changes
- Added `addClickEditFunctionality()` function to enable single-click cell editing
- Implemented `handleCellClick()` event handler that:
  - Detects clicks on editable table cells
  - Prevents editing of TaskID column and parent task names
  - Automatically selects the row and triggers edit mode
  - Simulates double-click event to activate editing
- Integrated the click editing setup into the Gantt chart initialization with proper timing delays
- Added event cleanup to prevent duplicate listeners

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f60f9cede1f465fb3fb18f85c834644/curry-forge)

👀 [Preview Link](https://7f60f9cede1f465fb3fb18f85c834644-curry-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f60f9cede1f465fb3fb18f85c834644</projectId>-->
<!--<branchName>curry-forge</branchName>-->