### PR TITLE
Replace duration column with end date in Gantt grid

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,6 +77,7 @@ var ganttChart = new ej.gantt.Gantt({
         id: 'TaskID',
         name: 'TaskName',
         startDate: 'StartDate',
+        endDate: 'EndDate',
         duration: 'Duration',
         progress: 'Progress',
         dependency: 'Predecessor',

--- a/main.js
+++ b/main.js
@@ -121,7 +121,7 @@ var ganttChart = new ej.gantt.Gantt({
         { field: 'TaskID', headerText: 'ID', width: 50, textAlign: 'Center', allowEditing: false },
         { field: 'TaskName', headerText: 'Tarefa', width: 250, allowEditing: true, clipMode: 'EllipsisWithTooltip' },
         { field: 'StartDate', headerText: 'Início', width: 90, format: 'dd/MM/yy', textAlign: 'Center', allowEditing: true, editType: 'datepickeredit' },
-        { field: 'Duration', headerText: 'Dur.', width: 60, textAlign: 'Center', allowEditing: true, editType: 'numericedit' },
+        { field: 'EndDate', headerText: 'Final', width: 90, format: 'dd/MM/yy', textAlign: 'Center', allowEditing: true, editType: 'datepickeredit' },
         { field: 'Progress', headerText: 'Prog.', width: 70, textAlign: 'Center', allowEditing: true, editType: 'numericedit' },
         { field: 'Predecessor', headerText: 'Pred.', width: 80, textAlign: 'Center', allowEditing: true, editType: 'stringedit', clipMode: 'EllipsisWithTooltip' }
     ],


### PR DESCRIPTION
## Purpose

The user requested to replace the duration column in the Gantt chart grid with an end date column. Instead of showing task duration, they wanted to display when each task ends.

## Code changes

- Added `endDate: 'EndDate'` to the task field mapping configuration
- Replaced the Duration column with EndDate column in the grid columns array:
  - Changed field from 'Duration' to 'EndDate'
  - Updated header text from 'Dur.' to 'Final'
  - Changed edit type from 'numericedit' to 'datepickeredit'
  - Updated width from 60 to 90 pixels to accommodate date format
  - Added date formatting ('dd/MM/yy') consistent with StartDate column

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f60f9cede1f465fb3fb18f85c834644/neon-den)

👀 [Preview Link](https://7f60f9cede1f465fb3fb18f85c834644-neon-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f60f9cede1f465fb3fb18f85c834644</projectId>-->
<!--<branchName>neon-den</branchName>-->